### PR TITLE
fixed class content where was created class content_search-engine-opt…

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,22 +25,31 @@
         </div>
     </div>
     <div class="hero"></div>
+    <!--
+        The IDs were not used by the CSS file and classes that were called were repeated by the CSS file when just one class for items
+         and one call in the CSS file would do the same result.
+        I’ve created a class called content_search-engine-optimization to replace the classes search-engine-optimization, 
+        online-reputation-management, and social-media-marketing, on the CSS file those classes are called just one time
+        replacing the repeated code on CSS.
+        The IDs were deleted from the code because they were not used by the code. 
+        I did the same for img and h2, where I call content_search-engine-optimization h2 and content_search-engine-optimization img.
+   -->
     <div class="content">
-        <div class="search-engine-optimization">
+        <div class="content_search-engine-optimization">
             <img src="./src/assets/images/search-engine-optimization.jpg" class="float-left" />
             <h2>Search Engine Optimization</h2>
             <p>
                 The dominance of mobile internet use means that users are searching for the right business as they travel, shop, or sit on their couch at home. Search Engine Optimization (SEO) allows you to increase your visibility and find the right customers for your business.
             </p>
         </div>
-        <div id="online-reputation-management" class="online-reputation-management">
+        <div class="content_search-engine-optimization">
             <img src="./src/assets/images/online-reputation-management.jpg" class="float-right" />
             <h2>Online Reputation Management</h2>
             <p>
                 The web is full of opinions, and some of these can be negative. Social media allows anyone with an internet connection to say whatever they want about your business. Online Reputation Management gives you the control over what potential customers see when they search for your business.
             </p>
         </div>
-        <div id="social-media-marketing" class="social-media-marketing">
+        <div class="content_search-engine-optimization">
             <img src="./src/assets/images/social-media-marketing.jpg" class="float-left" />
             <h2>Social Media Marketing</h2>
             <p>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -102,7 +102,7 @@ p {
     max-width: 150px;
 }
 
-.search-engine-optimization {
+.content_search-engine-optimization {
     margin-bottom: 20px;
     padding: 50px;
     height: 300px;
@@ -111,47 +111,11 @@ p {
     color: #ffffff;
 }
 
-.online-reputation-management {
-    margin-bottom: 20px;
-    padding: 50px;
-    height: 300px;
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    background-color: #0072bb;
-    color: #ffffff;
-}
-
-.social-media-marketing {
-    margin-bottom: 20px;
-    padding: 50px;
-    height: 300px;
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    background-color: #0072bb;
-    color: #ffffff;
-}
-
-.search-engine-optimization img {
-    max-height: 200px;
-}
-
-.online-reputation-management img {
-    max-height: 200px;
-}
-
-.social-media-marketing img {
+.content_search-engine-optimization img {
     max-height: 200px;
 }
 
 .search-engine-optimization h2 {
-    margin-bottom: 20px;
-    font-size: 36px;
-}
-
-.online-reputation-management h2 {
-    margin-bottom: 20px;
-    font-size: 36px;
-}
-
-.social-media-marketing h2 {
     margin-bottom: 20px;
     font-size: 36px;
 }


### PR DESCRIPTION
I’ve created a class called content_item to replace the classes search-engine-optimization, 
online-reputation-management, and social-media-marketing, on the CSS file those classes are called just one time
replacing the repeated code on CSS.
The IDs were refactored to call properly the links associeted. 
I did the same for img and h2, where I call content_search-engine-optimization h2 and content_search-engine-optimization img.
Also included main tag to show that there is the main content of this document
Added section tag to define with section of this document.